### PR TITLE
Feat: 오션키퍼 설치 링크 연동(안드로이드/ios 구분)

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -36,10 +36,31 @@ function Dashboard() {
       </div>
 
       {/* 신청하러 가기 버튼 */}
-      <div className="text-[24px] py-3 flex justify-center text-decoration-none"
-        style={{ backgroundColor: "#72A0BF" }}>
+      <div
+        className="text-[24px] py-3 flex justify-center text-decoration-none"
+        style={{ backgroundColor: "#72A0BF" }}
+      >
         <button
-          onClick={() => navigate("/calendar")}
+          onClick={() => {
+            const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
+
+            if (/android/i.test(userAgent)) {
+              window.open(
+                "https://play.google.com/store/apps/details?id=com.letspl.oceankeeper&pcampaignid=web_share",
+                "_blank"
+              );
+            } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+              window.open(
+                "https://apps.apple.com/kr/app/%EC%98%A4%EC%85%98%ED%82%A4%ED%8D%BC/id6470431291",
+                "_blank"
+              );
+            } else {
+              window.open(
+                "https://play.google.com/store/apps/details?id=com.letspl.oceankeeper&pcampaignid=web_share",
+                "_blank"
+              );
+            }
+          }}
           className="text-white font-medium cursor-pointer hover:no-underline focus:no-underline active:no-underline"
         >
           해양 봉사활동 신청하러 가기 →


### PR DESCRIPTION
## ✨ 개요
활동 신청 버튼 클릭 시, 사용자의 기기 종류에 따라 해당 스토어(Play Store / App Store)로 연결되도록 기능을 개선했습니다.

## 🔧 변경 사항
- 버튼 클릭 시 navigator.userAgent를 활용하여 기기 OS(Android / iOS) 감지 로직 추가
- 안드로이드 기기 → Google Play 스토어로 이동
- iOS 기기 → Apple App Store로 이동
- window.open()을 사용하여 외부 링크 새 탭에서 열리도록 처리

## ✅ 구현된 기능
 - 안드로이드 기기에서 버튼 클릭 시 Play Store 앱 페이지 열림
 - iOS 기기에서 버튼 클릭 시 App Store 앱 페이지 열림
 - 기존 버튼 디자인 및 스타일 유지

