### PR TITLE
refactor: 히트맵 줌 레벨별 scale/opacity/blur 값 세분화 조정

### DIFF
--- a/src/pages/RecordsPage.tsx
+++ b/src/pages/RecordsPage.tsx
@@ -232,11 +232,66 @@ const RecordsPage: React.FC = () => {
         let opacityAdjust = 1.0;
         let blurPx = 10;
 
-        if (level <= 5) { scaleFactor = 0.02; opacityAdjust = 0.2; blurPx = 4; }
-        else if (level <= 8) { scaleFactor = 0.06; opacityAdjust = 0.3; blurPx = 10; }
-        else if (level <= 11) { scaleFactor = 0.15; opacityAdjust = 0.5; blurPx = 15; }
-        else { scaleFactor = 1.2; opacityAdjust = 0.7; blurPx = 15; }
-
+        if (level <= 5) {
+           // 크기
+           scaleFactor = 0.025;  
+           // 투명도
+           opacityAdjust = 0.4; 
+           blurPx = 15;          
+        } 
+        // 1. 500m 이하
+        else if (level <= 6) {
+           // 크기
+           scaleFactor = 0.05;  
+           // 투명도
+           opacityAdjust = 0.5; 
+           blurPx = 15;          
+        } 
+        // 2. 1km 구간
+        else if (level <= 7) {
+           // 크기
+           scaleFactor = 0.09;   
+           // 투명도(높을수록 색감을 쨍하게 올림)
+           opacityAdjust = 0.6; 
+           blurPx = 12;
+        }
+        // 3. 2km 구간
+        else if (level <= 8) {
+           // 크기
+           scaleFactor = 0.2;  
+           // 투명도
+           opacityAdjust = 0.6; 
+           blurPx = 15;
+        } 
+        // 4. 4km 구간
+        else if (level <= 9) {
+           scaleFactor = 0.4;   
+           opacityAdjust = 0.7; 
+           blurPx = 20;
+        } 
+        // 5. 8km 구간
+        else if (level <= 10) {
+           scaleFactor = 0.6; 
+           opacityAdjust = 0.7; 
+           blurPx = 20;
+        } 
+        // 6. 16km 구간
+        else if (level <= 11) {
+           scaleFactor = 0.8; 
+           opacityAdjust = 1.0; 
+           blurPx = 20;
+        } 
+        // 7. 32km 구간
+        else if (level <= 12) {
+           scaleFactor = 1.1; 
+           opacityAdjust = 1.1; 
+           blurPx = 20;
+        }
+        else {
+           scaleFactor = 1.2;
+           opacityAdjust = 1.4;
+           blurPx = 20;
+        }
         this.node.style.left = `${sw.x}px`;
         this.node.style.top = `${ne.y}px`;
         this.node.style.width = `${width * scaleFactor}px`;
@@ -247,7 +302,9 @@ const RecordsPage: React.FC = () => {
         this.node.style.transform = `translate(${diffX}px, ${diffY}px)`;
 
         this.node.style.opacity = (this.baseOpacity * opacityAdjust).toString();
+
         this.node.style.filter = `blur(${blurPx}px)`;
+
       };
 
       // allMapData를 사용하여 히트맵 생성


### PR DESCRIPTION
## 🔍 Summary
- 지도 줌 레벨에 따라 히트맵 크기, 투명도, 블러 값을 단계별로 조정

## 💡 Changes
- 지도 줌 레벨을 실제 거리 기준(약 500m ~ 32km)으로 구간화
- 각 구간별로 히트맵 시각 요소를 다음 기준으로 조정
  - **scaleFactor**: 줌 레벨이 낮을수록(넓은 영역) 점 크기를 키워 분포 인지 강화
  - **opacityAdjust**: 고배율로 갈수록 투명도를 높여 밀집 지역 강조
  - **blurPx**: 저배율에서는 번짐을 줄이고, 중·고배율에서는 자연스러운 밀도 표현 유지

### 🔧 세부 조정 기준
- **≤ 500m (level ≤ 5)**  
  - scaleFactor 0.025 / opacity 0.4  
  - 개별 포인트 과도 노출 방지
- **1km ~ 2km (level 6~7)**  
  - scaleFactor 0.05\~0.09 / opacity 0.5\~0.6  
  - 활동 분포 형태가 자연스럽게 이어지도록 조정
- **4km ~ 8km (level 8~10)**  
  - scaleFactor 0.2\~0.6 / opacity 0.6\~0.7  
  - 지역 단위 밀집도 가시화
- **16km 이상 (level ≥ 11)**  
  - scaleFactor 0.8 이상 / opacity 최대 1.4  
  - 광역 단위 활동 집중 구간을 명확히 강조

## ✅ Result
- 줌 인/아웃 시 히트맵이 갑자기 뭉개지거나 사라지지 않음
- 지도 배율 변화에 따라 일관된 밀도 인지 가능
- 전체 분포 → 지역 집중 → 지점 단위 분석 흐름이 자연스럽게 연결됨

<img width="700" height="690" alt="image" src="https://github.com/user-attachments/assets/0c1c1360-a4a0-4d8d-9a74-483dda4abe29" />

<img width="700" height="770" alt="image" src="https://github.com/user-attachments/assets/5af67aac-a333-47cc-bef6-32132104301d" />
