### PR TITLE
Feat/heatmap

### DIFF
--- a/src/pages/RecordsPage.tsx
+++ b/src/pages/RecordsPage.tsx
@@ -77,7 +77,7 @@ const RecordsPage: React.FC = () => {
         const listRes = await instance.get("/api/activity-records", {
           params: {
             page: page,
-            size: 10,
+            size: 200,  // 임시 수정 - 한 페이지에 기존 10개 로드
           },
         });
 
@@ -634,7 +634,7 @@ const RecordsPage: React.FC = () => {
           )}
 
           {/* 6. 페이지네이션 */}
-          <div className="flex justify-center items-center gap-3 py-3 border-t border-gray-200 bg-white relative z-20">
+          {/* <div className="flex justify-center items-center gap-3 py-3 border-t border-gray-200 bg-white relative z-20">
             <button
               onClick={() => setPage(Math.max(0, page - 1))}
               disabled={page === 0}
@@ -652,7 +652,7 @@ const RecordsPage: React.FC = () => {
             >
               다음
             </button>
-          </div>
+          </div> */}
         </div>
       </div>
 

--- a/src/pages/RecordsPage.tsx
+++ b/src/pages/RecordsPage.tsx
@@ -232,11 +232,66 @@ const RecordsPage: React.FC = () => {
         let opacityAdjust = 1.0;
         let blurPx = 10;
 
-        if (level <= 5) { scaleFactor = 0.02; opacityAdjust = 0.2; blurPx = 4; }
-        else if (level <= 8) { scaleFactor = 0.06; opacityAdjust = 0.3; blurPx = 10; }
-        else if (level <= 11) { scaleFactor = 0.15; opacityAdjust = 0.5; blurPx = 15; }
-        else { scaleFactor = 1.2; opacityAdjust = 0.7; blurPx = 15; }
-
+        if (level <= 5) {
+           // 크기
+           scaleFactor = 0.025;  
+           // 투명도
+           opacityAdjust = 0.4; 
+           blurPx = 15;          
+        } 
+        // 1. 500m 이하
+        else if (level <= 6) {
+           // 크기
+           scaleFactor = 0.05;  
+           // 투명도
+           opacityAdjust = 0.5; 
+           blurPx = 15;          
+        } 
+        // 2. 1km 구간
+        else if (level <= 7) {
+           // 크기
+           scaleFactor = 0.09;   
+           // 투명도(높을수록 색감을 쨍하게 올림)
+           opacityAdjust = 0.6; 
+           blurPx = 12;
+        }
+        // 3. 2km 구간
+        else if (level <= 8) {
+           // 크기
+           scaleFactor = 0.2;  
+           // 투명도
+           opacityAdjust = 0.6; 
+           blurPx = 15;
+        } 
+        // 4. 4km 구간
+        else if (level <= 9) {
+           scaleFactor = 0.4;   
+           opacityAdjust = 0.7; 
+           blurPx = 20;
+        } 
+        // 5. 8km 구간
+        else if (level <= 10) {
+           scaleFactor = 0.6; 
+           opacityAdjust = 0.7; 
+           blurPx = 20;
+        } 
+        // 6. 16km 구간
+        else if (level <= 11) {
+           scaleFactor = 0.8; 
+           opacityAdjust = 1.0; 
+           blurPx = 20;
+        } 
+        // 7. 32km 구간
+        else if (level <= 12) {
+           scaleFactor = 1.1; 
+           opacityAdjust = 1.1; 
+           blurPx = 20;
+        }
+        else {
+           scaleFactor = 1.2;
+           opacityAdjust = 1.4;
+           blurPx = 20;
+        }
         this.node.style.left = `${sw.x}px`;
         this.node.style.top = `${ne.y}px`;
         this.node.style.width = `${width * scaleFactor}px`;
@@ -247,7 +302,9 @@ const RecordsPage: React.FC = () => {
         this.node.style.transform = `translate(${diffX}px, ${diffY}px)`;
 
         this.node.style.opacity = (this.baseOpacity * opacityAdjust).toString();
+
         this.node.style.filter = `blur(${blurPx}px)`;
+
       };
 
       // allMapData를 사용하여 히트맵 생성


### PR DESCRIPTION
## 🔍 Summary  
- 히트맵 페이지 이동 시 중첩 렌더링 문제를 해결하기 위해 조회 방식을 임시 변경하였습니다.  
- 프론트엔드 페이지 사이즈를 확장하고 페이지 이동 버튼을 제거하여 히트맵 렌더링 안정성을 확보하였습니다.  


## 💡 Changes  
1. **페이지 사이즈 확장 (10 → 200)**  
   - 히트맵 데이터 조회 시 페이지 사이즈를 10에서 200으로 확장  
   - 페이지 이동 없이 한 번에 충분한 데이터를 조회하도록 구조 변경  

2. **페이지 이동 버튼 제거**  
   - 페이지 이동 시 히트맵 레이어가 중첩되던 문제를 방지하기 위해  
     페이지 이동 버튼 UI 제거  
   - 데이터 재조회로 인한 히트맵 중복 렌더링 원천 차단  

3. **히트맵 렌더링 안정성 개선**  
   - 페이지 전환 없이 단일 데이터 세트 기준으로 히트맵을 렌더링하도록 수정  
   - 지도 상 히트맵 중첩 및 잔상 문제 해결  

## ✅ Test Checklist  
- [x] 페이지 사이즈 200 기준 히트맵 정상 렌더링 확인  
- [x] 페이지 이동 버튼 제거 후 UI 정상 동작 확인  
- [x] 히트맵 중첩 및 잔상 현상 미발생 확인  
- [x] 데이터 조회 및 지도 인터랙션 정상 동작 확인  


  

<img width="1621" height="1145" alt="image" src="https://github.com/user-attachments/assets/ab32ac71-ad25-4be4-9664-4068a14f7a88" />

  
  

<img width="394" height="493" alt="image" src="https://github.com/user-attachments/assets/58c08abf-7de1-4a7f-9743-600e663b48a8" />

- 기존 페이지 버튼(위 빨간 네모) 제거